### PR TITLE
3 zephyr3.4

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env]
-platform = ststm32@~16.1.0
+platform = ststm32
 board = disco_f051r8
 framework = zephyr
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,22 +1,22 @@
-#include <zephyr.h>
-#include <version.h>
+
+#include <zephyr/kernel.h>
 #include <string.h>
-#include <sys/printk.h>
-#include <console/console.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/console/console.h>
 
 void main(void)
 {
-   printk("Hello! I'm running Zephyr %s on %s, a %s board.\n\n ",
-           KERNEL_VERSION_STRING, CONFIG_BOARD, CONFIG_ARCH);
+    printk("Hello! I'm running on the %s, a %s board.\n\n ",
+           CONFIG_BOARD, CONFIG_ARCH);
 
-   console_getline_init();
-   printk("Enter a line finishing with Enter:\n");
+	console_getline_init();
+	printk("Enter a line finishing with Enter:\n");
 
-   while (1)
-   {
-       printk("> ");
-       char *s = console_getline();
-       printk("Typed line: %s\n", s);
-       printk("Last char was: 0x%x\n", s[strlen(s) - 1]);
-   }
+	while (1)
+    {
+        printk("> ");
+		char *s = console_getline();
+		printk("Typed line: %s\n", s);
+		printk("Last char was: 0x%x\n", s[strlen(s) - 1]);
+	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,3 @@
-
 #include <zephyr/kernel.h>
 #include <string.h>
 #include <zephyr/sys/printk.h>
@@ -9,14 +8,14 @@ void main(void)
     printk("Hello! I'm running on the %s, a %s board.\n\n ",
            CONFIG_BOARD, CONFIG_ARCH);
 
-	console_getline_init();
-	printk("Enter a line finishing with Enter:\n");
+    console_getline_init();
+    printk("Enter a line finishing with Enter:\n");
 
-	while (1)
+    while (1)
     {
         printk("> ");
-		char *s = console_getline();
-		printk("Typed line: %s\n", s);
-		printk("Last char was: 0x%x\n", s[strlen(s) - 1]);
-	}
+        char *s = console_getline();
+        printk("Typed line: %s\n", s);
+        printk("Last char was: 0x%x\n", s[strlen(s) - 1]);
+    }
 }

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,6 +1,9 @@
-cmake_minimum_required(VERSION 3.13.1)
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
 set(DTC_OVERLAY_FILE ./usart2_overlay.dts)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(STM23F0DISC_EchoConsole)
 
 FILE(GLOB app_sources ../src/*.c*)


### PR DESCRIPTION
Update zephyr sources to support version 3.4.

Changes based on
https://github.com/zephyrproject-rtos/zephyr/tree/zephyr-v3.4.0/samples/subsys/console/getline

Closes #3 